### PR TITLE
More arch types to be recognized

### DIFF
--- a/nodejs-maven-plugin/pom.xml
+++ b/nodejs-maven-plugin/pom.xml
@@ -170,6 +170,30 @@
             <activation>
                 <os>
                     <family>linux</family>
+                    <arch>x86</arch>
+                </os>
+            </activation>
+            <properties>
+                <nodejs.classifier>linux-x86</nodejs.classifier>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux-x86-386</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>i386</arch>
+                </os>
+            </activation>
+            <properties>
+                <nodejs.classifier>linux-x86</nodejs.classifier>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux-x86-686</id>
+            <activation>
+                <os>
+                    <family>linux</family>
                     <arch>i686</arch>
                 </os>
             </activation>
@@ -178,7 +202,19 @@
             </properties>
         </profile>
         <profile>
-            <id>linux-x64</id>
+            <id>linux-x64-x86_64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <properties>
+                <nodejs.classifier>linux-x64</nodejs.classifier>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux-x64-amd64</id>
             <activation>
                 <os>
                     <family>linux</family>


### PR DESCRIPTION
Added architecture types to be recognized based on the list at
http://lopica.sourceforge.net/os.html

Without this modification correct executable type for some JDK's "os.arch" property value won't be recognized.
