### PR TITLE
update to correct version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following POM plugin configuration will extract the NodeJs executable to dir
       <plugin>
         <groupId>com.github.skwakman.nodejs-maven-plugin</groupId>
         <artifactId>nodejs-maven-plugin</artifactId>
-        <version>1.0.5-node.0.10.25</version>
+        <version>1.0.5-node-0.10.25</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
The version number has a typo, which means copying and pasting the example would not work.
